### PR TITLE
Fix broken tabs on the trade page

### DIFF
--- a/app/templates/trade/trade.html
+++ b/app/templates/trade/trade.html
@@ -5,23 +5,23 @@
     <div class="card-header">
         <ul class="nav nav-tabs md-tabs" id="trade-tabs" role="tablist">
             <li class="nav-item" role="presentation">
-                <a class="nav-link active" data-mdb-toggle="tab" href="#stock-tab-pane" role="tab">Stock</a>
+                <a class="nav-link active" data-mdb-tab-init href="#stock-tab-pane" role="tab">Stock</a>
             </li>
             <li class="nav-item" role="presentation">
-                <a class="nav-link" data-mdb-toggle="tab" href="#option-tab-pane" role="tab">Single Option</a>
+                <a class="nav-link" data-mdb-tab-init href="#option-tab-pane" role="tab">Single Option</a>
             </li>
             <li class="nav-item" role="presentation">
-                <a class="nav-link" data-mdb-toggle="tab" href="#vertical-tab-pane" role="tab">Vertical Spread</a>
+                <a class="nav-link" data-mdb-tab-init href="#vertical-tab-pane" role="tab">Vertical Spread</a>
             </li>
             <li class="nav-item" role="presentation">
-                <a class="nav-link" data-mdb-toggle="tab" href="#condor-tab-pane" role="tab">Iron Condor</a>
+                <a class="nav-link" data-mdb-tab-init href="#condor-tab-pane" role="tab">Iron Condor</a>
             </li>
         </ul>
     </div>
     <div class="card-body">
         <div class="tab-content pt-2" id="trade-tabs-content">
 
-            <div class="tab-pane fade show active" id="stock-tab-pane" role="tabpanel">
+            <div class="tab-pane show active" id="stock-tab-pane" role="tabpanel">
                 <h4>Stock Order</h4>
                 <form method="POST" action="{{ url_for('trade.trading_page') }}">
                     {{ stock_form.hidden_tag() }}
@@ -44,7 +44,7 @@
                 </form>
             </div>
 
-            <div class="tab-pane fade" id="option-tab-pane" role="tabpanel">
+            <div class="tab-pane" id="option-tab-pane" role="tabpanel">
                 <h4>Single Option Order</h4>
                 <form method="POST" action="{{ url_for('trade.trading_page') }}">
                     {{ option_form.hidden_tag() }}
@@ -76,7 +76,7 @@
                 </form>
             </div>
 
-            <div class="tab-pane fade" id="vertical-tab-pane" role="tabpanel">
+            <div class="tab-pane" id="vertical-tab-pane" role="tabpanel">
                 <h4>Vertical Spread Order</h4>
                  <form method="POST" action="{{ url_for('trade.trading_page') }}">
                     {{ vertical_form.hidden_tag() }}
@@ -107,7 +107,7 @@
                 </form>
             </div>
 
-            <div class="tab-pane fade" id="condor-tab-pane" role="tabpanel">
+            <div class="tab-pane" id="condor-tab-pane" role="tabpanel">
                 <h4>Iron Condor Order</h4>
                  <form method="POST" action="{{ url_for('trade.trading_page') }}">
                      {{ condor_form.hidden_tag() }}


### PR DESCRIPTION
- Replaced the deprecated `data-mdb-toggle` attribute with `data-mdb-tab-init` to align with the updated MDBootstrap 5 library.
- Removed the `fade` class from the tab panes to resolve a rendering issue where the tab content would not appear after the MDBootstrap version upgrade.
- The tabs on the trade page now switch between different order types correctly.