### PR TITLE
Fix option trade submission error

### DIFF
--- a/app/trade/routes.py
+++ b/app/trade/routes.py
@@ -20,11 +20,11 @@ def handle_trade_request(form, handler_class):
 
     # Special handling for dynamically populated select fields
     if isinstance(form, (OptionOrderForm, VerticalSpreadForm, IronCondorForm)):
-        submitted_expiration = request.form.get(f'{form.prefix}-expiration_date')
+        submitted_expiration = request.form.get(f'{form._prefix}-expiration_date')
         if submitted_expiration:
             form.expiration_date.choices = [(submitted_expiration, submitted_expiration)]
     if isinstance(form, OptionOrderForm):
-        submitted_strike = request.form.get(f'{form.prefix}-strike')
+        submitted_strike = request.form.get(f'{form._prefix}-strike')
         if submitted_strike:
             form.strike.choices = [(submitted_strike, submitted_strike)]
 


### PR DESCRIPTION
- Corrected an `AttributeError` in the `handle_trade_request` function that occurred when trying to access the form prefix.
- The code was incorrectly trying to use `form.prefix`, which does not exist.
- The fix replaces `form.prefix` with `form._prefix` to correctly access the internal prefix attribute of the WTForms object.
- This allows the backend to correctly retrieve data from prefixed forms, such as the single option order form.