### PR TITLE
Add support and resistance for multiple periods

### DIFF
--- a/app/research/forms.py
+++ b/app/research/forms.py
@@ -1,8 +1,20 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, SubmitField
+from wtforms import StringField, SubmitField, SelectField
 from wtforms.validators import DataRequired
 
 class ResearchForm(FlaskForm):
     """Form for submitting a stock symbol for research."""
     symbol = StringField('Stock Symbol', validators=[DataRequired()])
+    period = SelectField(
+        'Analysis Period',
+        choices=[
+            (32, '32 Days'),
+            (94, '94 Days'),
+            (185, '185 Days'),
+            (366, '366 Days')
+        ],
+        default=185,
+        coerce=int,
+        validators=[DataRequired()]
+    )
     submit = SubmitField('Get Analysis')

--- a/app/research/routes.py
+++ b/app/research/routes.py
@@ -66,6 +66,7 @@ def research_page():
 
     if form.validate_on_submit():
         symbol = form.symbol.data.upper()
+        period = form.period.data
         api = get_api_for_current_user() # Get the user's API client
         if not api:
             flash('Cannot fetch data. Please check your API credentials in your profile.', 'danger')
@@ -73,7 +74,7 @@ def research_page():
 
         try:
             # --- UPDATED DATA FETCHING LOGIC ---
-            history_data = api.get_historical_prices(symbol)
+            history_data = api.get_historical_prices(symbol, period_days=period)
             if not history_data or not history_data.get('history') or history_data['history'] == 'null':
                  raise ValueError(f"No historical data found for the symbol '{symbol}'.")
             
@@ -102,7 +103,7 @@ def research_page():
             for r_level in rounded_resistance:
                 ax.axhline(y=r_level, color='red', linestyle='--', linewidth=2)
 
-            ax.set_title(f'{symbol} Support & Resistance Levels (Last 185 Days)', fontsize=20)
+            ax.set_title(f'{symbol} Support & Resistance Levels (Last {period} Days)', fontsize=20)
             ax.set_xlabel('Date', fontsize=14)
             ax.set_ylabel('Price (USD)', fontsize=14)
             ax.grid(True)

--- a/app/templates/research/research.html
+++ b/app/templates/research/research.html
@@ -4,19 +4,30 @@
 <div class="card mb-4">
     <div class="card-body">
         <h4 class="card-title">Stock Research</h4>
-        <p class="card-text">Enter a stock symbol to generate a support and resistance analysis for the last 185 days.</p>
+        <p class="card-text">Enter a stock symbol and select a period to generate a support and resistance analysis.</p>
         <form method="POST" action="{{ url_for('research.research_page') }}">
             {{ form.hidden_tag() }}
-            <div class="input-group">
-                <div data-mdb-input-init class="form-outline flex-fill">
-                    {{ form.symbol(class="form-control", placeholder="e.g., AAPL, TSLA") }}
-                    {{ form.symbol.label(class="form-label") }}
+            <div class="row align-items-end">
+                <div class="col-md-6 mb-3 mb-md-0">
+                    <div data-mdb-input-init class="form-outline">
+                        {{ form.symbol(class="form-control") }}
+                        {{ form.symbol.label(class="form-label") }}
+                    </div>
+                    {% for error in form.symbol.errors %}
+                        <div class="text-danger small ms-1 mt-2">{{ error }}</div>
+                    {% endfor %}
                 </div>
-                {{ form.submit(class="btn btn-primary") }}
+                <div class="col-md-4 mb-3 mb-md-0">
+                    {{ form.period.label(class="form-label") }}
+                    {{ form.period(class="form-select") }}
+                    {% for error in form.period.errors %}
+                        <div class="text-danger small ms-1 mt-2">{{ error }}</div>
+                    {% endfor %}
+                </div>
+                <div class="col-md-2">
+                    {{ form.submit(class="btn btn-primary w-100") }}
+                </div>
             </div>
-            {% for error in form.symbol.errors %}
-                <div class="text-danger small ms-1 mt-2">{{ error }}</div>
-            {% endfor %}
         </form>
     </div>
 </div>


### PR DESCRIPTION
This commit introduces a dropdown menu on the research page that allows users to select the time period for support and resistance analysis.

The following periods are now available:
- 32 days
- 94 days
- 185 days
- 366 days

The backend has been updated to fetch historical data for the selected period, and the chart title now dynamically reflects the chosen timeframe.