### PR TITLE
fix: Convert 'Close' column to numeric for plotting

### DIFF
--- a/app/research/routes.py
+++ b/app/research/routes.py
@@ -78,6 +78,7 @@ def research_page():
             stock_df = pd.DataFrame(day_data)
             stock_df['date'] = pd.to_datetime(stock_df['date'])
             stock_df.rename(columns={'date': 'Date', 'close': 'Close'}, inplace=True)
+            stock_df['Close'] = pd.to_numeric(stock_df['Close'])
 
             support, resistance = find_support_resistance(stock_df)
             rounded_support = list(dict.fromkeys([custom_round(s) for s in support]))


### PR DESCRIPTION
- The 'Close' column from the API was being treated as a string, causing the Plotly chart to display incorrect values for the closing price.
- This commit ensures the 'Close' column is converted to a numeric type before being used in the chart.